### PR TITLE
Fix Release APK workflow: bump deprecated GitHub Actions to v4

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Restore keystore
         run: |
@@ -28,7 +28,7 @@ jobs:
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu' # See 'Supported distributions' for available options
           java-version: '17'
@@ -37,7 +37,7 @@ jobs:
         run: ./gradlew assembleRelease --stacktrace
 
       - name: Upload build outputs (APKs)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-outputs
           path: app/build/outputs


### PR DESCRIPTION
## Summary
- The manually-triggered "Release APK" workflow (`.github/workflows/check.yaml`) has been auto-failing because it uses `actions/upload-artifact@v3`, which GitHub deprecated and now auto-fails at the start of the run (see the [deprecation notice](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)).
- Bumps `actions/upload-artifact@v3` → `@v4` to fix the failure.
- Also bumps `actions/checkout@v3` → `@v4` and `actions/setup-java@v3` → `@v4` for consistency, since they're on the same deprecated major version.

## Test plan
- [ ] Manually re-run the "Release APK" workflow after merging to confirm it completes successfully.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XMxGiXxZAauWaZq8tdoJ4h)_