### PR TITLE
Fix GitHub trending tab language filter and subtitle text

### DIFF
--- a/app/src/main/java/me/arunsharma/devupdates/ui/fragments/feed/GithubFragment.kt
+++ b/app/src/main/java/me/arunsharma/devupdates/ui/fragments/feed/GithubFragment.kt
@@ -56,7 +56,9 @@ class GithubFragment : BaseFragment(R.layout.fragment_feed_github) {
                             chip.setOnCheckedChangeListener { buttonView, isChecked ->
                                 if (isChecked) {
                                     val lang = buttonView.text.toString()
-                                    if (lang != DEFAULT_LANG) {
+                                    if (lang == DEFAULT_LANG) {
+                                        request.metadata?.remove(ServiceConstants.GITHUB_SELECTED_LANGUAGE)
+                                    } else {
                                         request.metadata?.put(ServiceConstants.GITHUB_SELECTED_LANGUAGE, lang)
                                     }
                                     viewModel.getData(request, forceUpdate = true)

--- a/source-github/src/main/java/com/devupdates/github/APIGithub.kt
+++ b/source-github/src/main/java/com/devupdates/github/APIGithub.kt
@@ -16,11 +16,12 @@ class APIGithub @Inject constructor(val service: ServiceGithub) : ServiceIntegra
         try {
             Timber.d("Debug--getData")
             val result = service.getTrending(request.metadata?.get(ServiceConstants.GITHUB_SELECTED_LANGUAGE) ?: "", "daily").map { item ->
+                val starsToday = (item.currentPeriodStars ?: 0).toString() + " stars today"
                 ServiceItem(
                     title = item.author + " / " + item.name,
                     description = item.description,
                     author = item.author,
-                    topTitleText = item.language + " ● " + item.currentPeriodStars + " stars today",
+                    topTitleText = if (item.language.isNullOrBlank()) starsToday else item.language + " ● " + starsToday,
                     likes = "★ " + item.stars?.toString(),
                     actionUrl = item.url,
                     sourceType = request.type.toString(),


### PR DESCRIPTION
## Summary
- **Fix the language filter chips.** `chipGroupLanguage` is a single-selection `ChipGroup`, and the chip listener only wrote the selected language into `request.metadata` when the tapped chip wasn't "All":
  ```kotlin
  if (lang != DEFAULT_LANG) {
      request.metadata?.put(ServiceConstants.GITHUB_SELECTED_LANGUAGE, lang)
  }
  ```
  So picking e.g. "Kotlin" then switching back to "All" was a no-op — the stale `"kotlin"` stayed in metadata, and `APIGithub` kept requesting `/trending/kotlin`, so the list still showed Kotlin repos while the chip UI showed "All" selected. Now selecting "All" removes the stored language so the request falls back to all-languages trending (`APIGithub`'s existing `?: ""` fallback), matching what the chip shows.
- **Fix the subtitle text.** `topTitleText` was built as `item.language + " ● " + item.currentPeriodStars + " stars today"`. When a trending repo has no listed language (fairly common — e.g. docs-only repos) or GitHub doesn't report a "stars today" count for it, Kotlin's `String + null` produces the literal string `"null"`, so the subtitle could read like `"● null stars today"` or `"null ● 123 stars today"`. Now falls back to `0` for a missing star count and omits the language segment entirely when it's blank.

## Test plan
- [ ] Build and run the app; open the GitHub trending tab, switch to a specific language chip (e.g. Kotlin), then switch back to "All" — confirm the list actually returns to all-languages trending rather than staying on the previously selected language (this sandbox's egress policy blocks `dl.google.com`/`jitpack.io`/`github.com`'s web UI, so a full Gradle build and live scrape could not be run here — please verify locally/in CI).
- [ ] Confirm trending repos without a listed language show a clean subtitle (no stray leading "● " or literal "null").


---
_Generated by [Claude Code](https://claude.ai/code/session_01XMxGiXxZAauWaZq8tdoJ4h)_