### PR TITLE
Make GitHub trending parser resilient to per-row parse failures

### DIFF
--- a/source-github/src/main/java/com/devupdates/github/APIGithub.kt
+++ b/source-github/src/main/java/com/devupdates/github/APIGithub.kt
@@ -22,7 +22,7 @@ class APIGithub @Inject constructor(val service: ServiceGithub) : ServiceIntegra
                     description = item.description,
                     author = item.author,
                     topTitleText = if (item.language.isNullOrBlank()) starsToday else item.language + " ● " + starsToday,
-                    likes = "★ " + item.stars?.toString(),
+                    likes = "★ " + (item.stars ?: 0),
                     actionUrl = item.url,
                     sourceType = request.type.toString(),
                     createdAt = System.currentTimeMillis(),

--- a/source-github/src/main/java/com/devupdates/github/GitHubTrendingParser.kt
+++ b/source-github/src/main/java/com/devupdates/github/GitHubTrendingParser.kt
@@ -23,67 +23,72 @@ object GitHubTrendingParser {
             }
     }
 
-    private fun parseTrendingItem(element: Element): GithubTrendingResponseItem {
-        val authorAndName = element.select("h2 > a")
-            .attr("href")
-            .toString()
-            .removePrefix("/")
-            .trimEnd()
-            .split("/")
-            .let { Pair(it[0], it[1]) }
-        val (author, repoName) = authorAndName
-        val url = "${ServiceGithub.ENDPOINT}/${authorAndName.first}/${authorAndName.second}"
-        val description = element.select("p").text()
+    private fun parseTrendingItem(element: Element): GithubTrendingResponseItem? {
+        return try {
+            val authorAndName = element.select("h2 > a")
+                .attr("href")
+                .toString()
+                .removePrefix("/")
+                .trimEnd()
+                .split("/")
+                .let { Pair(it[0], it[1]) }
+            val (author, repoName) = authorAndName
+            val url = "${ServiceGithub.ENDPOINT}/${authorAndName.first}/${authorAndName.second}"
+            val description = element.select("p").text()
 
-        val language = element.select("[itemprop=\"programmingLanguage\"]").text()
-        // "background-color:#563d7c;"
-        val languageColor = element.select(".repo-language-color")
-            .firstOrNull()
-            ?.attr("style")
-            ?.removePrefix("background-color:")
-            ?.trimStart() // Thanks for the leading space, GitHub
-            ?.let {
-                val colorSubstring = it.removePrefix("#")
-                if (colorSubstring.length == 3) {
-                    // Three digit hex, convert to 6 digits for Color.parseColor()
-                    "#${colorSubstring.replace(".".toRegex(), "$0$0")}"
-                } else {
-                    it
+            val language = element.select("[itemprop=\"programmingLanguage\"]").text()
+            // "background-color:#563d7c;"
+            val languageColor = element.select(".repo-language-color")
+                .firstOrNull()
+                ?.attr("style")
+                ?.removePrefix("background-color:")
+                ?.trimStart() // Thanks for the leading space, GitHub
+                ?.let {
+                    val colorSubstring = it.removePrefix("#")
+                    if (colorSubstring.length == 3) {
+                        // Three digit hex, convert to 6 digits for Color.parseColor()
+                        "#${colorSubstring.replace(".".toRegex(), "$0$0")}"
+                    } else {
+                        it
+                    }
                 }
-            }
 
-        // "3,441" stars, forks
-        val counts = element.select(".Link--muted.d-inline-block.mr-3")
-            .asSequence()
-            .map(Element::text)
-            .map { it.removeCommas() }
-            .map(String::toInt)
-            .toList()
+            // "3,441" stars, forks
+            val counts = element.select(".Link--muted.d-inline-block.mr-3")
+                .asSequence()
+                .map(Element::text)
+                .map { it.removeCommas() }
+                .mapNotNull(String::toIntOrNull)
+                .toList()
 
-        val stars = counts[0]
-        val forks = counts.getOrNull(1)
+            val stars = counts.getOrNull(0)
+            val forks = counts.getOrNull(1)
 
-        // "691 stars today"
-        val starsToday = element.select(".d-inline-block.float-sm-right").firstOrNull()
-            ?.text()
-            ?.removeCommas()
-            ?.let {
-                NUMBER_PATTERN.find(it)?.groups?.firstOrNull()?.value?.toInt() ?: run {
-                    d {  "$authorAndName didn't have today" }
-                    null
+            // "691 stars today"
+            val starsToday = element.select(".d-inline-block.float-sm-right").firstOrNull()
+                ?.text()
+                ?.removeCommas()
+                ?.let {
+                    NUMBER_PATTERN.find(it)?.groups?.firstOrNull()?.value?.toInt() ?: run {
+                        d {  "$authorAndName didn't have today" }
+                        null
+                    }
                 }
-            }
 
-        return GithubTrendingResponseItem(
-            author = author,
-            url = url,
-            name = repoName,
-            description = description,
-            stars = stars,
-            forks = forks,
-            currentPeriodStars = starsToday,
-            language = language,
-            languageColor = languageColor
-        )
+            GithubTrendingResponseItem(
+                author = author,
+                url = url,
+                name = repoName,
+                description = description,
+                stars = stars,
+                forks = forks,
+                currentPeriodStars = starsToday,
+                language = language,
+                languageColor = languageColor
+            )
+        } catch (exception: Exception) {
+            d { "Skipping trending item, failed to parse: ${exception.message}" }
+            null
+        }
     }
 }


### PR DESCRIPTION
## Context
After 1.0.20 shipped, the GitHub Trending tab is still showing "Something went wrong and we are sorry for that. Please try again later" (the generic fallback error text) on the default "All" view. That message specifically means the caught exception was neither an `HttpException` nor an `IOException` — it's some other `RuntimeException`, which points at `GitHubTrendingParser` throwing during HTML parsing rather than a network/HTTP failure.

## What I found
`GitHubTrendingParser.parse()` calls `.mapNotNull(GitHubTrendingParser::parseTrendingItem)`, but `parseTrendingItem()` never actually returned `null` — it only ever returned a valid item or **threw**. Several lines in it were unguarded:
- `href.split("/").let { Pair(it[0], it[1]) }` — throws `IndexOutOfBoundsException` if a repo card's link doesn't split into at least 2 segments.
- `counts[0]` — throws `IndexOutOfBoundsException` if the star/fork selector (`.Link--muted.d-inline-block.mr-3`) matches nothing for that card.
- `.map(String::toInt)` — throws `NumberFormatException` on any non-numeric count text.

Since `mapNotNull` doesn't catch exceptions, a single malformed/differently-structured card anywhere in the ~25-row trending list (a promoted entry, an edge-case repo, etc.) throws and kills the *entire* fetch — which matches exactly what's shown in the screenshot: the whole tab errors out rather than just one row being missing.

I don't have live access to `github.com`'s trending page from this environment to confirm GitHub changed its markup wholesale (web requests to `github.com` get intercepted by this sandbox's own tooling proxy, separate from the app) — but this fix is correct and worth shipping regardless of the exact trigger: it turns "one bad row nukes the whole tab" into "skip the bad row, show everything else."

## Changes
- `parseTrendingItem` now catches per-item parsing exceptions, logs them, and returns `null` so `mapNotNull` actually filters them out as intended.
- Star/fork counts use `toIntOrNull` instead of `toInt`, and `stars` is read via `counts.getOrNull(0)` instead of `counts[0]`.
- Fixed `likes` showing the literal text `"★ null"` now that `stars` is properly optional (same class of bug as the `topTitleText` fix in #38).

## Caveat
If the trending page's row container itself changed (e.g. the `.Box-row` class no longer exists at all), every row would fail to parse and the tab would still show an error — just now the more accurate `"List was empty! Usually this is a sign that parsing failed."` failure rather than a random per-row exception. If the error persists after this ships, the next step would be pulling the actual exception message/stack trace from Crashlytics (already integrated in this app) to see whether it's hitting that "list was empty" path, which would mean the scraper's CSS selectors need a real update against current GitHub markup.

## Test plan
- [ ] Build and run the app; open the GitHub trending tab and confirm it loads without the generic error (this sandbox can't run a full Gradle build — `dl.google.com`/`jitpack.io` are blocked — so please verify locally/in CI).
- [ ] If the error still reproduces, check Crashlytics for the actual exception/stack trace so the root cause can be pinned down precisely.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XMxGiXxZAauWaZq8tdoJ4h)_