### PR TITLE
Fix GitHub trending star/fork counts showing as 0

### DIFF
--- a/source-github/src/main/java/com/devupdates/github/GitHubTrendingParser.kt
+++ b/source-github/src/main/java/com/devupdates/github/GitHubTrendingParser.kt
@@ -53,16 +53,11 @@ object GitHubTrendingParser {
                     }
                 }
 
-            // "3,441" stars, forks
-            val counts = element.select(".Link--muted.d-inline-block.mr-3")
-                .asSequence()
-                .map(Element::text)
-                .map { it.removeCommas() }
-                .mapNotNull(String::toIntOrNull)
-                .toList()
-
-            val stars = counts.getOrNull(0)
-            val forks = counts.getOrNull(1)
+            // Prefer selecting by the stargazers/forks link's href, since it's a stable,
+            // semantic URL rather than GitHub's frequently-churned Primer CSS utility
+            // classes. Fall back to the old class-based selector if that ever comes back.
+            val stars = parseCount(element, "a[href$=stargazers]", fallbackIndex = 0)
+            val forks = parseCount(element, "a[href$=forks], a[href$=members]", fallbackIndex = 1)
 
             // "691 stars today"
             val starsToday = element.select(".d-inline-block.float-sm-right").firstOrNull()
@@ -90,5 +85,16 @@ object GitHubTrendingParser {
             d { "Skipping trending item, failed to parse: ${exception.message}" }
             null
         }
+    }
+
+    /**
+     * Reads a "3,441"-style count from [primarySelector] (an href-based selector, stable
+     * across GitHub's styling changes), falling back to the [fallbackIndex]-th match of the
+     * legacy class-based selector if the primary one finds nothing.
+     */
+    private fun parseCount(element: Element, primarySelector: String, fallbackIndex: Int): Int? {
+        val primary = element.select(primarySelector).firstOrNull()
+        val target = primary ?: element.select(".Link--muted.d-inline-block.mr-3").getOrNull(fallbackIndex)
+        return target?.text()?.removeCommas()?.toIntOrNull()
     }
 }


### PR DESCRIPTION
## Context
After 1.0.21 shipped, the GitHub Trending tab now loads correctly (the per-row resilience fix from #39 worked), but every item shows `★ 0` instead of a real star count — confirmed by a screenshot of real trending repos like `localsend/localsend` all showing `★ 0`.

## Diagnosis
The star/fork count selector, `.Link--muted.d-inline-block.mr-3`, is matching nothing on the current trending page, while the "stars today" badge selector (`.d-inline-block.float-sm-right`, e.g. "370 stars today") is still working fine — visible in the same screenshot. That narrows it down precisely: it's not a wholesale markup change, just those specific count links losing/changing that class combination, which is consistent with GitHub periodically renaming Primer CSS utility classes.

I tried to confirm the exact current class names directly, but this sandboxed environment's own tooling explicitly blocks all `github.com` web requests — including via `curl` with a browser user agent — with the message *"sessions are bound to their configured repositories. Use repository-scoped endpoints"*. That's a deliberate restriction on this session, not something to work around, so I can't verify the live markup from here.

## Fix
Rather than guess at GitHub's current CSS utility class names again, this switches to selecting the stargazers/forks count by the link's `href` (`a[href$=stargazers]`, `a[href$=forks]`/`a[href$=members]`) — a stable, semantic URL that's far less likely to change than styling classes — falling back to the old class-based selector if that ever comes back. This is non-regressive: if the href suffix guess is also wrong, behavior is identical to today (still 0); if it's right, real counts come back.

## Test plan
- [ ] Build and run the app; open the GitHub trending tab and confirm star counts show real numbers instead of `★ 0` (this sandbox can't run a full Gradle build or reach `github.com`'s web UI to verify directly — please check on-device).
- [ ] If counts are still `0` after this ships, the href suffix guess needs adjusting — at that point, pulling one repo card's raw HTML directly (e.g. via "View Page Source" in a browser on `github.com/trending`) would let me target the exact current selector instead of guessing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XMxGiXxZAauWaZq8tdoJ4h)_